### PR TITLE
add github action to automatically sync upstream changes

### DIFF
--- a/.github/workflows/sync-pr.yml
+++ b/.github/workflows/sync-pr.yml
@@ -1,0 +1,38 @@
+name: Sync Upstream
+
+on: 
+  schedule:
+    - cron: '0 12 * * 3'            # scheduled for 12pm every Wednesday UTC
+  workflow_dispatch:                # trigger manually
+
+jobs:
+  sync-upstream:
+    runs-on: ubuntu-latest
+    name: Sync latest commits from upstream repo
+    steps:
+      - name: Checkout target repo
+        uses: actions/checkout@v3
+        with:
+          ref: devel
+    
+      - name: Sync upstream changes
+        id: sync
+        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.1
+        with:
+          target_sync_branch: devel
+          # REQUIRED 'target_repo_token' exactly like this!
+          target_repo_token: ${{ secrets.GITHUB_TOKEN }}
+          upstream_sync_branch: devel
+          upstream_sync_repo: azimuth-cloud/azimuth-config
+        
+      # Step 3: Display a sample message based on the sync output var 'has_new_commits'
+      - name: New commits found
+        if: steps.sync.outputs.has_new_commits == 'true'
+        run: echo "New commits were found to sync."
+      
+      - name: No new commits
+        if: steps.sync.outputs.has_new_commits == 'false'
+        run: echo "There were no new commits."
+        
+      - name: Show value of 'has_new_commits'
+        run: echo ${{ steps.sync.outputs.has_new_commits }}


### PR DESCRIPTION
can't sync changes on main due to branch protections.

We should test upstream changes on "devel" ourselves before merging into main. We can rebuild our staging platform to use new values before merging into main

This PR sets up automated PRs to sync changes into main
