### PR TITLE
Disabling FIP-workstations

### DIFF
--- a/environments/stfc-base/inventory/group_vars/all/variables.yml
+++ b/environments/stfc-base/inventory/group_vars/all/variables.yml
@@ -186,3 +186,8 @@ azimuth_authenticator_federated_enabled: yes
 azimuth_authenticator_federated_provider: "openid"
 azimuth_authenticator_federated_protocol: "openid"
 azimuth_authenticator_federated_label: Login using IAM
+
+#######################################################################
+# Disabling FIP workstations
+azimuth_caas_workstation_ssh_enabled: no
+


### PR DESCRIPTION
Limits the number of FIPs that can be consumed by a project