### PR TITLE
ENH: Add link to our custom user docs

### DIFF
--- a/environments/stfc-base/inventory/group_vars/all/variables.yml
+++ b/environments/stfc-base/inventory/group_vars/all/variables.yml
@@ -179,6 +179,8 @@ azimuth_authenticator_federated_provider: "openid"
 azimuth_authenticator_federated_protocol: "openid"
 azimuth_authenticator_federated_label: Login using IAM
 
+azimuth_documentation_url: https://stfc.github.io/cloud-azimuth-user-docs/
+
 azimuth_theme_bootstrap_css_url: https://bootswatch.com/5/zephyr/bootstrap.css
 
 azimuth_theme_custom_css: |-


### PR DESCRIPTION
Replace the documentation link with our own STFC-specific user documentation link:
https://stfc.github.io/cloud-azimuth-user-docs/