### PR TITLE
BUG: Pin ansible-core below 2.19 until templating fixed across azimuth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible-core>=2.12 # require undef filter
+ansible-core>=2.12,<2.19 # require undef filter, pin below 2.19 until templating fixed
 azimuth-robotframework
 bcrypt==4.0.1  # this is the latest version that doesn't emit a warning
 jmespath


### PR DESCRIPTION
`ansible-core` 2.19 introduces multiple breaking changes to templating:
https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_12.html#example-implicit-boolean-conversion

Rather than contributing multiple upstream PRs, we should pin for now