### PR TITLE
Refactor opensearch: make unique for staging/prod, disable for dev

### DIFF
--- a/environments/stfc-base/inventory/group_vars/all/fluent_operator_user_opensearch_config.yml
+++ b/environments/stfc-base/inventory/group_vars/all/fluent_operator_user_opensearch_config.yml
@@ -1,0 +1,23 @@
+fluent_operator_user_opensearch_config:
+  host: "{{ fluent_operator_user_opensearch_host }}"
+  port: "{{ fluent_operator_user_opensearch_port }}"
+  httpPassword:
+    valueFrom:
+      secretKeyRef:
+        name: opensearch-credentials
+        key: password
+  httpUser:
+    valueFrom:
+      secretKeyRef:
+        name: opensearch-credentials
+        key: username
+  logstashFormat: true
+  logstashPrefix: "{{ fluent_operator_user_opensearch_logstash_prefix }}"
+  replaceDots: true
+  type: flb_type
+  traceError: true
+  suppressTypeName: true
+  timeKey: "@timestamp"
+  tls:
+    verify: false
+    debug: 1

--- a/environments/stfc-base/inventory/group_vars/all/user_cluster_fluent_operator_values.yml
+++ b/environments/stfc-base/inventory/group_vars/all/user_cluster_fluent_operator_values.yml
@@ -53,41 +53,7 @@ azimuth_capi_operator_fluent_operator_values:
       #   tag: "fb.metrics"
 
     output:
-      opensearch:
-        # TODO change this to point to opensearch "olaf" cluster (SCD department cluster)
-        host: opensearch.staging-worker.nubes.stfc.ac.uk
-        port: 443
-        httpPassword:
-          valueFrom:
-            secretKeyRef:
-              name: opensearch-credentials
-              key: password
-        httpUser:
-          valueFrom:
-            secretKeyRef:
-              name: opensearch-credentials
-              key: username
-        logstashFormat: true
-        # At the time of writing, custom addons have templating disabled:
-        # https://github.com/azimuth-cloud/capi-helm-charts/blob/affae0544b07c4b2e641b3b5bf990e561c055a91/charts/cluster-addons/templates/custom-addons.yaml#L15
-        # 1. Temporarily re-enable templating with an endraw
-        # 2. Template for Openstack Project ID by base64 decoding the user info from the cloud_credentials secret
-        #    a. https://github.com/azimuth-cloud/cluster-api-addon-provider/tree/main?tab=readme-ov-file#templates
-        #    b. Note, the "cluster" and "infra_cluster" are CRD types cluster.cluster.x-k8s.io and openstackcluster.infrastructure.cluster.x-k8s.io; not clusters.azimuth.stackhpc.com
-        # 3. Template for the Kubernetes UID of the cluster object, for it to be unique to the project
-        # 4. Re-disable templating
-        logstashPrefix: "{{ '{%- endraw %}' }}{% raw %}kube_logs_azimuth_{{ cluster.metadata.uid }}_projectid_{{ (cloud_identity.data[\"user_info.yaml\"] | b64decode
-          | fromyaml).project_id }}{% endraw %}{{ '{%- raw %}' }}"
-        # index: "azimuth_user_logs_<some_unique_name>"
-        replaceDots: true
-        type: flb_type
-        traceError: true
-        suppressTypeName: true
-        timeKey: "@timestamp"
-        tls:
-          verify: false
-          debug: 1
-
+      opensearch: "{{ fluent_operator_user_opensearch_config }}"
       loki:
         enable: true
         host: loki-stack

--- a/environments/stfc-dev/inventory/group_vars/all/variables.yml
+++ b/environments/stfc-dev/inventory/group_vars/all/variables.yml
@@ -24,3 +24,8 @@ azimuth_clusters_enabled: false
 
 #Disables pulling community images, remove line to pull images
 community_images: {}
+
+# Disable opensearch output on dev instances
+fluent_operator_user_opensearch_config: {}
+user_cluster_logging_user: 
+user_cluster_logging_pass: 

--- a/environments/stfc-ha/inventory/group_vars/all/cluster_fluent_operator_values.yml
+++ b/environments/stfc-ha/inventory/group_vars/all/cluster_fluent_operator_values.yml
@@ -53,31 +53,7 @@ capi_cluster_fluent_operator_values:
       #   tag: "fb.metrics"
 
     output:
-      opensearch:
-        # TODO change this to point to opensearch "olaf" cluster (SCD department cluster)
-        host: opensearch.staging-worker.nubes.stfc.ac.uk
-        port: 443
-        httpPassword:
-          valueFrom:
-            secretKeyRef:
-              name: opensearch-credentials
-              key: password
-        httpUser:
-          valueFrom:
-            secretKeyRef:
-              name: opensearch-credentials
-              key: username
-        logstashFormat: true
-        logstashPrefix: "kube_logs_{{ capi_cluster_release_name }}"
-        replaceDots: true
-        type: flb_type
-        traceError: true
-        suppressTypeName: true
-        timeKey: "@timestamp"
-        tls:
-          verify: false
-          debug: 1
-
+      opensearch: "{{ fluent_operator_cluster_opensearch_config }}"
       loki:
         enable: true
         host: loki-stack

--- a/environments/stfc-ha/inventory/group_vars/all/fluent_operator_cluster_opensearch_config.yml
+++ b/environments/stfc-ha/inventory/group_vars/all/fluent_operator_cluster_opensearch_config.yml
@@ -1,0 +1,23 @@
+fluent_operator_cluster_opensearch_config:
+  host: "{{ fluent_operator_cluster_opensearch_host }}"
+  port: "{{ fluent_operator_cluster_opensearch_port }}"
+  httpPassword:
+    valueFrom:
+      secretKeyRef:
+        name: opensearch-credentials
+        key: password
+  httpUser:
+    valueFrom:
+      secretKeyRef:
+        name: opensearch-credentials
+        key: username
+  logstashFormat: true
+  logstashPrefix: "{{ fluent_operator_cluster_opensearch_logstash_prefix }}"
+  replaceDots: true
+  type: flb_type
+  traceError: true
+  suppressTypeName: true
+  timeKey: "@timestamp"
+  tls:
+    verify: false
+    debug: 1

--- a/environments/stfc-production/inventory/group_vars/all/variables.yml
+++ b/environments/stfc-production/inventory/group_vars/all/variables.yml
@@ -21,3 +21,24 @@ community_images_default_visibility: private
 
 # Disable ssh-workstations
 azimuth_caas_workstation_ssh_enabled: false
+
+##################################################################################
+# Fluent Operator Opensearch Config
+fluent_operator_cluster_opensearch_host: opensearch.staging-worker.nubes.stfc.ac.uk
+fluent_operator_user_opensearch_host: opensearch.staging-worker.nubes.stfc.ac.uk
+
+fluent_operator_cluster_opensearch_port: 443
+fluent_operator_user_opensearch_port: 443
+
+fluent_operator_cluster_opensearch_logstash_prefix: "kube_logs_{{ capi_cluster_release_name }}"
+# At the time of writing, custom addons have templating disabled:
+  # https://github.com/azimuth-cloud/capi-helm-charts/blob/affae0544b07c4b2e641b3b5bf990e561c055a91/charts/cluster-addons/templates/custom-addons.yaml#L15
+  # 1. Temporarily re-enable templating with an endraw
+  # 2. Template for Openstack Project ID by base64 decoding the user info from the cloud_credentials secret
+  #    a. https://github.com/azimuth-cloud/cluster-api-addon-provider/tree/main?tab=readme-ov-file#templates
+  #    b. Note, the "cluster" and "infra_cluster" are CRD types cluster.cluster.x-k8s.io and openstackcluster.infrastructure.cluster.x-k8s.io; not clusters.azimuth.stackhpc.com
+  # 3. Template for the Kubernetes UID of the cluster object, for it to be unique to the project
+  # 4. Re-disable templating
+fluent_operator_user_opensearch_logstash_prefix: "{{ '{%- endraw %}' }}{% raw %}kube_logs_azimuth_user_cluster_{{ cluster.metadata.uid }}_projectid_{{ (cloud_identity.data[\"user_info.yaml\"] | b64decode
+    | fromyaml).project_id }}{% endraw %}{{ '{%- raw %}' }}"
+##################################################################################

--- a/environments/stfc-staging/inventory/group_vars/all/variables.yml
+++ b/environments/stfc-staging/inventory/group_vars/all/variables.yml
@@ -32,3 +32,24 @@ community_images_default_visibility: private
 
 # Disable ssh-workstations
 azimuth_caas_workstation_ssh_enabled: false
+
+##################################################################################
+# Fluent Operator Opensearch Config
+fluent_operator_cluster_opensearch_host: opensearch.staging-worker.nubes.stfc.ac.uk
+fluent_operator_user_opensearch_host: opensearch.staging-worker.nubes.stfc.ac.uk
+
+fluent_operator_cluster_opensearch_port: 443
+fluent_operator_user_opensearch_port: 443
+
+fluent_operator_cluster_opensearch_logstash_prefix: "kube_logs_{{ capi_cluster_release_name }}"
+# At the time of writing, custom addons have templating disabled:
+  # https://github.com/azimuth-cloud/capi-helm-charts/blob/affae0544b07c4b2e641b3b5bf990e561c055a91/charts/cluster-addons/templates/custom-addons.yaml#L15
+  # 1. Temporarily re-enable templating with an endraw
+  # 2. Template for Openstack Project ID by base64 decoding the user info from the cloud_credentials secret
+  #    a. https://github.com/azimuth-cloud/cluster-api-addon-provider/tree/main?tab=readme-ov-file#templates
+  #    b. Note, the "cluster" and "infra_cluster" are CRD types cluster.cluster.x-k8s.io and openstackcluster.infrastructure.cluster.x-k8s.io; not clusters.azimuth.stackhpc.com
+  # 3. Template for the Kubernetes UID of the cluster object, for it to be unique to the project
+  # 4. Re-disable templating
+fluent_operator_user_opensearch_logstash_prefix: "{{ '{%- endraw %}' }}{% raw %}kube_logs_azimuth_staging_user_cluster_{{ cluster.metadata.uid }}_projectid_{{ (cloud_identity.data[\"user_info.yaml\"] | b64decode
+    | fromyaml).project_id }}{% endraw %}{{ '{%- raw %}' }}"
+##################################################################################


### PR DESCRIPTION
Make the opensearch fluent-operator output config unique for staging/prod; and disable the output by default for dev as:
- Credentials are missing
- We don't want personal dev instance logs on our production/staging DBs

(Note: prod and staging details identical for now during internal testing)