### PR TITLE
BUG: Reset modal background color to black

### DIFF
--- a/environments/stfc-base/inventory/group_vars/all/variables.yml
+++ b/environments/stfc-base/inventory/group_vars/all/variables.yml
@@ -198,14 +198,6 @@ azimuth_theme_custom_css: |-
     color: var(--bs-light) !important;
   }
 
-  .modal pre {
-    background-color: var(--bs-primary) !important;
-    color: var(--bs-light);
-    padding: 1rem;
-    max-height: 400px;
-    overflow: scroll;
-  }
-
   .sticky-footer a {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
Modal colour shouldn't have been set to primary (blue):
<img width="953" height="391" alt="image" src="https://github.com/user-attachments/assets/83262c17-fd69-4591-ae3a-b99104b98310" />
