### PR TITLE
BUG: Hotfix for the worst of the cluster quota prediction errors

### DIFF
--- a/environments/stfc-base/inventory/group_vars/all/variables.yml
+++ b/environments/stfc-base/inventory/group_vars/all/variables.yml
@@ -81,6 +81,9 @@ azimuth_capi_operator_cluster_templates_extra: |-
               "values": {
                 "kubernetesVersion": kube_version_dot,
                 "machineImageId": image_id,
+                "controlPlane": {
+                  "machineCount": azimuth_capi_operator_capi_helm_control_plane_count,
+                },
               },
             },
             recursive = True


### PR DESCRIPTION
See https://github.com/azimuth-cloud/azimuth/issues/427

This will fix quota predictions for machine count, RAM and CPU.

It won't fix predictions for volumes and volume storage, those are more complex as they are per-node flavour; whereas Azimuth's UI code tries to take them from the CAPI template.

It also won't add quota checks for things like Security Groups, that needs upstream changes.