### PR TITLE
BUG: Disable fluentbit serviceMonitor so it can deploy on user clusters with monitoring disabled

### DIFF
--- a/environments/stfc-base/inventory/group_vars/all/user_cluster_fluent_operator_values.yml
+++ b/environments/stfc-base/inventory/group_vars/all/user_cluster_fluent_operator_values.yml
@@ -4,7 +4,7 @@ azimuth_capi_operator_fluent_operator_values:
     enable: true
 
     serviceMonitor:
-      enable: true
+      enable: false
       interval: 30s
       path: /api/v2/metrics/prometheus
       scrapeTimeout: 10s


### PR DESCRIPTION
When users disable cluster monitoring, deployment wasn't working as its waiting for a servicemonitor CRD that doesn't exist:
```
pyhelm3.errors.Error: Error: unable to build kubernetes objects from release manifest: resource mapping not found for name: "fluent-bit" namespace: "monitoring-system" from "": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
ensure CRDs are installed first
  Error  Logging  25s  kopf  Handler 'handle_addon_updated' failed with an exception. Will retry.
Traceback (most recent call last):
  File "/venv/lib/python3.12/site-packages/kopf/_core/actions/execution.py", line 274, in execute_handler_once
    result = await invoke_handler(
             ^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.12/site-packages/kopf/_core/actions/execution.py", line 369, in invoke_handler
    result = await invocation.invoke(
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.12/site-packages/ko...encode()))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.12/site-packages/pyhelm3/command.py", line 235, in run
    raise error_cls(proc.returncode, stdout, stderr)
```