### PR TITLE
ENH: Disable the default admin user for ArgoCD

### DIFF
--- a/environments/stfc-base/inventory/group_vars/all/user_cluster_k8s_app_configs.yml
+++ b/environments/stfc-base/inventory/group_vars/all/user_cluster_k8s_app_configs.yml
@@ -78,3 +78,9 @@ azimuth_capi_operator_app_templates_jupyterhub_default_values:
 
           c.JupyterHub.redirect_to_server = False
           c.JupyterHub.authenticator_class = RemoteUserAuthenticator
+
+azimuth_capi_operator_app_templates_argocd_default_values:
+  argo-cd:
+    configs:
+      cm:
+        admin.enabled: false


### PR DESCRIPTION
Makes it clearer login isn't needed as when all users are disabled, there is a message saying login is disabled

<img width="463" height="186" alt="image" src="https://github.com/user-attachments/assets/724a5046-9fb5-459a-a31f-7a93a9e860cf" />

Login isn't needed as auth is disabled for argocd, as authentication/access control is handled by Zenith/KeyCloak:
https://github.com/azimuth-cloud/azimuth-charts/blob/bd55609a2471608d0dc8bc55d0208425de81d4dd/argocd-azimuth/values.yaml#L10