### PR TITLE
ENH: Switch huggingface repo to point to our own

### DIFF
--- a/environments/stfc-base/inventory/group_vars/all/user_cluster_k8s_app_configs.yml
+++ b/environments/stfc-base/inventory/group_vars/all/user_cluster_k8s_app_configs.yml
@@ -87,3 +87,8 @@ azimuth_capi_operator_app_templates_argocd_default_values:
 
 azimuth_capi_operator_app_templates_huggingface_llm_chart_name: stfc-azimuth-llm-chat
 azimuth_capi_operator_app_templates_huggingface_llm_chart_repo: https://stfc.github.io/cloud-helm-charts/
+azimuth_capi_operator_app_templates_huggingface_llm_default_values:
+  azimuth-llm:
+    api:
+      monitoring:
+        enabled: false # HOTFIX: https://github.com/stackhpc/azimuth-llm/issues/116

--- a/environments/stfc-base/inventory/group_vars/all/user_cluster_k8s_app_configs.yml
+++ b/environments/stfc-base/inventory/group_vars/all/user_cluster_k8s_app_configs.yml
@@ -84,3 +84,6 @@ azimuth_capi_operator_app_templates_argocd_default_values:
     configs:
       cm:
         admin.enabled: false
+
+azimuth_capi_operator_app_templates_huggingface_llm_chart_name: stfc-azimuth-llm-chat
+azimuth_capi_operator_app_templates_huggingface_llm_chart_repo: https://stfc.github.io/cloud-helm-charts/


### PR DESCRIPTION
Change default model from Deepseek to Microsoft Phi, set a default context limit, and update vLLM

Requires https://github.com/stfc/cloud-helm-charts/pull/87 to be merged first