### PR TITLE
Disable HuggingFace until DeepSeek is replaced

### DIFF
--- a/environments/stfc-base/inventory/group_vars/all/user_cluster_k8s_app_configs.yml
+++ b/environments/stfc-base/inventory/group_vars/all/user_cluster_k8s_app_configs.yml
@@ -84,3 +84,6 @@ azimuth_capi_operator_app_templates_argocd_default_values:
     configs:
       cm:
         admin.enabled: false
+
+# Disabled until we resolve the default model being DeepSeek
+azimuth_capi_operator_app_templates_huggingface_llm_enabled: false


### PR DESCRIPTION
The default model for HuggingFace is deepseek which isn't allowed under STFC policy.

Also the default context length is too long and causes issues.

From my research and tests, the only way to modify this is via subcharting, but this is still a point of conversation within the team:
https://github.com/stfc/cloud-helm-charts/pull/87

https://github.com/stfc/cloud-azimuth-config/pull/58

For now, for initial launch, HuggingFace should be disabled.