### PR TITLE
ENH: Add MoU button to azimuth homepage

### DIFF
--- a/environments/stfc-base/inventory/group_vars/all/variables.yml
+++ b/environments/stfc-base/inventory/group_vars/all/variables.yml
@@ -184,6 +184,10 @@ azimuth_authenticator_federated_label: Login using IAM
 
 azimuth_documentation_url: https://stfc.github.io/cloud-azimuth-user-docs/
 
+# During Early Preview, we will link to the MoU using the support URL, 
+# and style it (below) to be an MoU button
+azimuth_support_url: https://stfc.atlassian.net/wiki/spaces/CLOUDKB/pages/1000702963/Azimuth+Memorandum+of+Understanding+MOU
+
 azimuth_theme_bootstrap_css_url: https://bootswatch.com/5/zephyr/bootstrap.css
 
 azimuth_theme_custom_css: |-
@@ -225,3 +229,45 @@ azimuth_theme_custom_css: |-
     flex-shrink: 0;
     vertical-align: middle;
   }
+
+  /* ------------------------------------------------------ */
+  /* Change "Support" button to "MoU" during early preview */
+  /* Apologies for the horrible-ness */
+  /* Hide the original icon */
+  a[href*="Azimuth+Memorandum+of+Understanding+MOU"] svg.fa-life-ring {
+      display: none !important;
+  }
+
+  /* Hide original text */
+  a[href*="Azimuth+Memorandum+of+Understanding+MOU"] {
+      font-size: 0 !important; /* Shrink original text */
+      color: transparent !important; /* Make original text invisible */
+      white-space: nowrap;
+      display: inline-flex;
+      align-items: center;
+      text-decoration: none;
+      position: relative;
+  }
+
+  /* Inject the custom SVG as background + "MoU" label */
+  a[href*="Azimuth+Memorandum+of+Understanding+MOU"]::before {
+      content: "";
+      display: inline-block;
+      width: 1em;
+      height: 1em;
+      font-size: 1rem;
+      background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><path fill="%23f8f9fa" d="M128 128C128 92.7 156.7 64 192 64L341.5 64C358.5 64 374.8 70.7 386.8 82.7L493.3 189.3C505.3 201.3 512 217.6 512 234.6L512 512C512 547.3 483.3 576 448 576L192 576C156.7 576 128 547.3 128 512L128 128zM336 122.5L336 216C336 229.3 346.7 240 360 240L453.5 240L336 122.5zM216 128C202.7 128 192 138.7 192 152C192 165.3 202.7 176 216 176L264 176C277.3 176 288 165.3 288 152C288 138.7 277.3 128 264 128L216 128zM216 224C202.7 224 192 234.7 192 248C192 261.3 202.7 272 216 272L264 272C277.3 272 288 261.3 288 248C288 234.7 277.3 224 264 224L216 224zM286.3 384C275 384 264.4 389.1 257.4 397.9L197.3 473C189 483.3 190.7 498.5 201 506.7C211.3 514.9 226.5 513.3 234.7 502.9L281.8 444.1L297 494.8C300 505 309.4 511.9 320 511.9L424 511.9C437.3 511.9 448 501.2 448 487.9C448 474.6 437.3 463.9 424 463.9L337.9 463.9L321.8 410.3C317.1 394.6 302.7 383.9 286.3 383.9z"/></svg>');
+      background-repeat: no-repeat;
+      background-size: contain;
+      background-position: center;
+      vertical-align: middle;
+  }
+
+  /* Add replacement label */
+  a[href*="Azimuth+Memorandum+of+Understanding+MOU"]::after {
+      content: "Memorandum of Understanding";
+      color: inherit;
+      font-size: 0.875rem;
+      vertical-align: middle;
+  }
+  /* ------------------------------------------------------ */


### PR DESCRIPTION
Azimuth only exposes:
- Changing the docs/support link
- Adding custom CSS

So the only non-forking method to add a custom MoU link was to override the support link using CSS

Sorry for the horrible-ness

<img width="758" height="334" alt="image" src="https://github.com/user-attachments/assets/53bfed22-270f-48a6-895c-08bf998fa4d9" />
