### PR TITLE
fix fluent-operator OOM by increasing resource limits

### DIFF
--- a/environments/stfc-base/inventory/group_vars/all/user_cluster_addons.yml
+++ b/environments/stfc-base/inventory/group_vars/all/user_cluster_addons.yml
@@ -14,7 +14,7 @@ azimuth_capi_operator_helm_addon_overrides:
         chart:
           repo: https://fluent.github.io/helm-charts
           name: fluent-operator
-          version: 3.4.0
+          version: 3.5.0
         values: "{{ azimuth_capi_operator_fluent_operator_values }}"
     opensearch-credentials:
       kind: Manifests

--- a/environments/stfc-base/inventory/group_vars/all/user_cluster_fluent_operator_values.yml
+++ b/environments/stfc-base/inventory/group_vars/all/user_cluster_fluent_operator_values.yml
@@ -1,5 +1,15 @@
 ---
 azimuth_capi_operator_fluent_operator_values:
+  operator:
+    resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi
+    requests:
+      cpu: 100m
+      memory: 20Mi
+    disableComponentControllers: "fluentd"
+
   fluentbit:
     enable: true
 
@@ -16,7 +26,7 @@ azimuth_capi_operator_fluent_operator_values:
         memory: 400Mi
       requests:
         cpu: 10m
-        memory: 25Mi
+        memory: 100Mi
     
     annotations:
       fluentbit.io/exclude: "true"

--- a/environments/stfc-base/inventory/group_vars/all/user_cluster_fluent_operator_values.yml
+++ b/environments/stfc-base/inventory/group_vars/all/user_cluster_fluent_operator_values.yml
@@ -1,5 +1,6 @@
 ---
 azimuth_capi_operator_fluent_operator_values:
+
   operator:
     resources:
     limits:
@@ -12,31 +13,27 @@ azimuth_capi_operator_fluent_operator_values:
 
   fluentbit:
     enable: true
-
-    serviceMonitor:
-      enable: false
-      interval: 30s
-      path: /api/v2/metrics/prometheus
-      scrapeTimeout: 10s
-      secure: false
     
+    serviceMonitor:
+      enable: true
+
     resources:
       limits:
-        cpu: 500m
-        memory: 400Mi
+        cpu: 2
+        memory: 1.0Gi
       requests:
         cpu: 10m
-        memory: 100Mi
-    
+        memory: 25Mi
+  
     annotations:
       fluentbit.io/exclude: "true"
       promtheus.io/scrape: "true"
 
     input:
-      tail:
-        enable: true
-      systemd:
-        enable: true
+      fluentBitMetrics:
+        scrapeInterval: "2"
+        scrapeOnStart: true
+        tag: "fb.metrics"
 
     output:
       opensearch: "{{ fluent_operator_user_opensearch_config }}"
@@ -55,15 +52,19 @@ azimuth_capi_operator_fluent_operator_values:
         autoKubernetesLabels: "off" # Only seems to work for labels and annotations, not metadata. Disabling and doing it myself!
         lineFormat: json
 
+      prometheusMetricsExporter:
+        match: "fb.metrics"
+        metricsExporter:
+          host: "0.0.0.0"
+          port: 2020
+          addLabels:
+            app: "fluentbit"
+
     filter:
       kubernetes:
         enable: true
         labels: true
         annotations: false
-      containerd:
-        enable: true
-      systemd:
-        enable: true
 
   fluentd:
     enable: false

--- a/environments/stfc-ha/inventory/group_vars/all/cluster_addons.yml
+++ b/environments/stfc-ha/inventory/group_vars/all/cluster_addons.yml
@@ -27,7 +27,7 @@ capi_cluster_helm_addon_overrides:
         chart:
           repo: https://fluent.github.io/helm-charts
           name: fluent-operator
-          version: 3.4.0
+          version: 3.5.0
         values: "{{ capi_cluster_fluent_operator_values }}"
     opensearch-credentials:
       kind: Manifests

--- a/environments/stfc-ha/inventory/group_vars/all/cluster_fluent_operator_values.yml
+++ b/environments/stfc-ha/inventory/group_vars/all/cluster_fluent_operator_values.yml
@@ -1,32 +1,39 @@
 ---
 capi_cluster_fluent_operator_values:
+  
+  operator:
+    resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi
+    requests:
+      cpu: 100m
+      memory: 20Mi
+    disableComponentControllers: "fluentd"
+
   fluentbit:
     enable: true
     
     serviceMonitor:
       enable: true
-      interval: 30s
-      path: /api/v2/metrics/prometheus
-      scrapeTimeout: 10s
-      secure: false
 
     resources:
       limits:
-        cpu: 500m
-        memory: 400Mi
+        cpu: 2
+        memory: 1.0Gi
       requests:
         cpu: 10m
         memory: 25Mi
-    
+  
     annotations:
       fluentbit.io/exclude: "true"
       promtheus.io/scrape: "true"
 
     input:
-      tail:
-        enable: true
-      systemd:
-        enable: true
+      fluentBitMetrics:
+        scrapeInterval: "2"
+        scrapeOnStart: true
+        tag: "fb.metrics"
 
     output:
       opensearch: "{{ fluent_operator_cluster_opensearch_config }}"
@@ -45,15 +52,19 @@ capi_cluster_fluent_operator_values:
         autoKubernetesLabels: "off" # Only seems to work for labels and annotations, not metadata. Disabling and doing it myself!
         lineFormat: json
 
+      prometheusMetricsExporter:
+        match: "fb.metrics"
+        metricsExporter:
+          host: "0.0.0.0"
+          port: 2020
+          addLabels:
+            app: "fluentbit"
+
     filter:
       kubernetes:
         enable: true
         labels: true
         annotations: false
-      containerd:
-        enable: true
-      systemd:
-        enable: true
 
   fluentd:
     enable: false


### PR DESCRIPTION
bring fluent-bit operator values in-line with cloud helm chart so we're running the same logging config on all our clusters. 